### PR TITLE
Empty cells on clear to fix issues #6

### DIFF
--- a/src/ui-listView.js
+++ b/src/ui-listView.js
@@ -3,7 +3,7 @@
  * @name ui-listView
  * @description
  * Displays a list of items.  Designed to handle large data sets.
- */
+ */c
 var module = angular.module("ui-listView", [
     "ui-listView.templates"
 ]);
@@ -287,6 +287,7 @@ class UIListView {
         if (!this.rows || removeRows) {
             this.rows = [];
         }
+        this.cells = [];
         this.options.range = this.visibleRange = {
             index: 0,
             length: 0

--- a/src/ui-listView.js
+++ b/src/ui-listView.js
@@ -3,7 +3,7 @@
  * @name ui-listView
  * @description
  * Displays a list of items.  Designed to handle large data sets.
- */c
+ */
 var module = angular.module("ui-listView", [
     "ui-listView.templates"
 ]);


### PR DESCRIPTION
When the binded list became empty, the cells are not remove.
This can be reproduced here http://jsfiddle.net/Ly55fmnu/
